### PR TITLE
chore: remove `jenkins_nonroot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,26 @@
-ansible-jenkins-centos
-======================
+# ansible-jenkins-centos
 
 ansible role to install Jenkins on CentOS
 
 https://galaxy.ansible.com/suzuki-shunsuke/jenkins-centos/
 
-Requirements
-------------
+## Requirements
 
 Nothing.
 
-Role Variables
---------------
+## Role Variables
 
-* jenkins_jdk: JDK yum package name. The default is "java-1.8.0-openjdk". If you don't want to install jdk by yum, set "no"
-* jenkins_state: jenkins service state. The default is "no", which means don't change jenkins service state.
-* jenins_enabled: Whether the service should start on boot. In default don't change jenkins service state.
+name | required | default | description
+--- | --- | --- | ---
+jenkins_jdk | no | java-1.8.0-openjdk | JDK yum package name. If you don't want to install jdk by yum, set "no"
+jenkins_state | no | | jenkins service state. The default is "no", which means don't change jenkins service state
+jenins_enabled | no | | Whether the service should start on boot. By default don't change jenkins service state
 
-Dependencies
-------------
+## Dependencies
 
 Nothing.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
@@ -32,9 +29,9 @@ Example Playbook
     jenkins_jdk: no
     jenkins_state: started
     jenkins_enabled: yes
+    become: yes
 ```
 
-License
--------
+## License
 
-MIT
+[MIT](LICENSE)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,31 +5,25 @@
   yum:
     name: "{{ jenkins_jdk }}"
     update_cache: yes
-  become: "{{ jenkins_nonroot }}"
   when: jenkins_jdk != "no" and jenkins_jdk
 - name: Add repository
   get_url:
     url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
     dest: /etc/yum.repos.d/jenkins.repo
-  become: "{{ jenkins_nonroot }}"
 - name: Add jenkins-ci.org.key
   rpm_key:
     key: https://jenkins-ci.org/redhat/jenkins-ci.org.key
-  become: "{{ jenkins_nonroot }}"
 - name: Install jenkins
   yum:
     name: jenkins
     update_cache: yes
-  become: "{{ jenkins_nonroot }}"
 - name: Change jenkins state
   service:
     name: jenkins
     state: "{{ jenkins_state }}"
-  become: "{{ jenkins_nonroot }}"
   when: jenkins_state != "no" and jenkins_state
 - name: Change whether the service should start on boot
   service:
     name: jenkins
     enabled: "{{ jenkins_enabled }}"
-  become: "{{ jenkins_nonroot }}"
   when: jenkins_enabled != "default"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,3 +4,4 @@
   - role: ansible-jenkins-centos
     jenkins_state: started
     jenkins_enabled: yes
+    become: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-# vars file for jenkins-centos
-jenkins_nonroot: "{{ (ansible_env.HOME == '/root') | ternary('no', 'yes') }}"


### PR DESCRIPTION
BREAKING CHANGE: `become: yes` is required unless the remote user is root