### PR TITLE
feat: improve jenkins_state specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Nothing.
 name | required | default | description
 --- | --- | --- | ---
 jenkins_jdk | no | java-1.8.0-openjdk | JDK yum package name. If you don't want to install jdk by yum, set "no"
-jenkins_state | no | | jenkins service state. The default is "no", which means don't change jenkins service state
-jenins_enabled | no | | Whether the service should start on boot. By default don't change jenkins service state
+jenkins_state | no | | jenkins service state. By default the service restarts if any results of tasks are "changed". If the value is "not restarted", the service doesn't restart
+jenins_enabled | no | | Whether the service should start on boot. By default don't change the setting
 jenins_port | no | | `JENKINS_PORT` in `/etc/sysconfig/jenkins`
 jenkins_listen_address | no | | `JENKINS_LISTEN_ADDRESS` in `/etc/sysconfig/jenkins`
 jenkins_args | no | | `JENKINS_ARGS` in `/etc/sysconfig/jenkins`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
 # defaults file for jenkins-centos
 jenkins_jdk: java-1.8.0-openjdk
-jenkins_state: no
-jenkins_enabled: default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,20 +3,24 @@
 # https://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins+on+Red+Hat+distributions
 - name: Install JDK
   yum:
-    name: "{{ jenkins_jdk }}"
+    name: "{{jenkins_jdk}}"
     update_cache: yes
   when: jenkins_jdk != "no" and jenkins_jdk
+  register: result_install_jdk
 - name: Add repository
   get_url:
     url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
     dest: /etc/yum.repos.d/jenkins.repo
+  register: result_add_repository
 - name: Add jenkins-ci.org.key
   rpm_key:
     key: https://jenkins-ci.org/redhat/jenkins-ci.org.key
+  register: result_add_rpm_key
 - name: Install jenkins
   yum:
     name: jenkins
     update_cache: yes
+  register: result_install_jenkins
 
 - name: set JENKINS_PORT
   lineinfile:
@@ -24,26 +28,36 @@
     regexp: "^JENKINS_PORT="
     line: 'JENKINS_PORT="{{jenkins_port}}"'
   when: jenkins_port is defined
+  register: result_jenkins_port
 - name: set JENKINS_LISTEN_ADDRESS
   lineinfile:
     path: /etc/sysconfig/jenkins
     regexp: "^JENKINS_LISTEN_ADDRESS="
     line: 'JENKINS_LISTEN_ADDRESS="{{jenkins_listen_address}}"'
   when: jenkins_listen_address is defined
+  register: result_jenkins_listen_address
 - name: set JENKINS_ARGS
   lineinfile:
     path: /etc/sysconfig/jenkins
     regexp: "^JENKINS_ARGS="
     line: 'JENKINS_ARGS="{{jenkins_args}}"'
   when: jenkins_args is defined
+  register: result_jenkins_args
 
 - name: Change jenkins state
   service:
     name: jenkins
-    state: "{{ jenkins_state }}"
-  when: jenkins_state != "no" and jenkins_state
+    state: "{{jenkins_state}}"
+  when: jenkins_state is defined and jenkins_state != "not restarted"
+
+- name: Change jenkins state
+  service:
+    name: jenkins
+    state: restarted
+  when: jenkins_state is undefined and (result_install_jdk.changed or result_add_repository.changed or result_add_rpm_key.changed or result_install_jenkins.changed or result_jenkins_port.changed or result_jenkins_listen_address.changed or result_jenkins_args.changed)
+
 - name: Change whether the service should start on boot
   service:
     name: jenkins
-    enabled: "{{ jenkins_enabled }}"
-  when: jenkins_enabled != "default"
+    enabled: "{{jenkins_enabled}}"
+  when: jenkins_enabled is defined


### PR DESCRIPTION
By default the service restarts if any results of tasks are "changed".
If the value is "not restarted", the service doesn't restart.

BREAKING_CHANGE: By default the service restarts if any results of tasks are "changed".